### PR TITLE
Now uses wiringpi2 instead of wiringpi.

### DIFF
--- a/src/WiringPin.py
+++ b/src/WiringPin.py
@@ -1,4 +1,4 @@
-import wiringpi
+import wiringpi2 as wiringpi
 
 wiringpi.wiringPiSetup()
 
@@ -9,8 +9,9 @@ class WiringPin:
         self.direction = direction
 
     def export(self):
-        wiringpi.pinMode(self.gpio_number,
-            wiringpi.OUTPUT if self.direction == "out" else wiringpi.INPUT)
+        wiringpi.pinMode(
+            self.gpio_number,
+            wiringpi.GPIO.OUTPUT if self.direction == "out" else wiringpi.GPIO.INPUT)
         return self
 
     def set_value(self, value):


### PR DESCRIPTION
I made this change because the install instructions in `README.md` failed (it wouldn't let me build wiringpi-python as I didn't have a necessary C header or something). I thought it'd be nice to get the module working in a more straightforward way, using `pip` to install `wiringpi2` (which seems to have superceded `wiringpi`) rather than the git submodule method in the readme.

This commit means you can just run `sudo pip install wiringpi2`. The only relevant API difference seems to be that `wiringpi.OUTPUT` is now `wiringpi2.GPIO.OUTPUT` in `wiringpi2`.

I've successfully run a "real world test" with an RF transmitter on my Pi B+, and I also successfully ran the unit test for the RF sender. I'm not able to test the receiver as I don't have a receiver hardware module.

Hope this helps! If the changes I've made don't make sense then that's cool - let me know if I've unintentionally broken anything. This library rocks!
